### PR TITLE
Cancel timeline listener before we discard the timeline store.

### DIFF
--- a/src/Client.tsx
+++ b/src/Client.tsx
@@ -45,6 +45,7 @@ export const Client: React.FC<ClientProps> = ({ clientStore }) => {
             }
             if (tls && tls !== timelineStore) {
                 console.log("(re)running timelineStore");
+                timelineStore?.stop();
                 tls.run();
             }
             if (mls && mls !== memberListStore) {

--- a/src/TimelineStore.tsx
+++ b/src/TimelineStore.tsx
@@ -208,6 +208,14 @@ class TimelineStore {
             this.running = true;
         })();
     };
+    stop = () => {
+        (async () => {
+            console.log("unsubscribing to timeline", this.room.id());
+            this.timelineListener?.cancel();
+            this.running = false;
+            console.log("unsubscribed to timeline", this.room.id());
+        })();
+    };
 
     subscribe = (listener: CallableFunction) => {
         this.listeners = [...this.listeners, listener];


### PR DESCRIPTION
This seems to the following errors:

> Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behaviour is unsupported and could change in a future version.


and I the things I saw like `Set` operations being applied > length.

I think we were getting duplicated update events from there being multiple subscriptions to the timeline. I think we probably need to revisit the architecture overall and the lifeclycle/role of the stores.