### PR TITLE
Fix being able to sign-in with a local non-https homeserver (`http://localhost:8008`)

### DIFF
--- a/src/ClientStore.tsx
+++ b/src/ClientStore.tsx
@@ -139,7 +139,7 @@ class ClientStore {
         this.clientState = ClientState.LoggingIn;
         this.emit();
         const client = await this.getClientBuilder()
-            .homeserverUrl(server)
+            .serverNameOrHomeserverUrl(server)
             .build();
 
         console.log("starting sdk...");

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -31,7 +31,7 @@ export const Login: React.FC<LoginProps> = ({ clientStore, loggingIn }) => {
                                     clientStore.login({
                                         username,
                                         password,
-                                        server: `https://${server}`,
+                                        server,
                                     });
                                 }}
                             >


### PR DESCRIPTION
Fix being able to sign-in with a local non-https homeserver (`http://localhost:8008`)

Previously, it would try to send the request to the malformed address: `https://http://localhost:8008/_matrix/client/versions`